### PR TITLE
Emit dlx failure events

### DIFF
--- a/deps/rabbitmq_event_exchange/src/rabbit_exchange_type_event.erl
+++ b/deps/rabbitmq_event_exchange/src/rabbit_exchange_type_event.erl
@@ -200,6 +200,10 @@ key(federation_link_status) ->
     <<"federation.link.status">>;
 key(federation_link_removed) ->
     <<"federation.link.removed">>;
+key(queue_dead_letter_failed) ->
+    <<"queue.dead.letter.failed">>;
+key(queue_dead_letter_recovered) ->
+    <<"queue.dead.letter.recovered">>;
 key(S) ->
     case string:tokens(atom_to_list(S), "_") of
         [_, "stats"] -> ignore;


### PR DESCRIPTION
## Proposed Changes

When quorum queue at-least-once dead-lettering fails — due to a missing DLX, no route, or a cycle — the rabbit_fifo_dlx_worker logs a warning only
once to avoid log spam. These one-time warnings are easy to miss, and stuck dead-lettered messages silently prevent Raft log truncation, leading to
unbounded disk growth even when the queue appears empty.

This PR emits rabbit_event events alongside the existing warning logs so that the [event exchange plugin](https://www.rabbitmq.com/docs/logging#
internal-events) can surface these failures to consumers programmatically. Two event types are introduced:

- queue_dead_letter_failed (routing key queue.dead.letter.failed) — emitted when dead-lettering fails due to missing_dlx, no_route, or cycle. A
reason property distinguishes the three cases.
- queue_dead_letter_recovered (routing key queue.dead.letter.recovered) — emitted when a previously broken route becomes viable again (DLX found, or
route discovered).

Events follow the same once-per-condition semantics as the existing logs: they fire once when the failure is first detected, and once when it
resolves. If the condition recurs, the event is emitted again.

This enables operators to build alerting on dead-lettering failures via the event exchange, rather than relying on log scraping.

Ref: https://github.com/rabbitmq/rabbitmq-server/discussions/14494

## Types of Changes

- [] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)

- [x] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [ ] I have read the `CONTRIBUTING.md` document
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it


